### PR TITLE
Fix import error (when running on linux: "python qgis2img")

### DIFF
--- a/qgis2img/__main__.py
+++ b/qgis2img/__main__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 
-import qgis2img.render
+from render import run
 import argparse
 
 parser = argparse.ArgumentParser(description="QGIS project file and layer image export tool")
 
 subs = parser.add_subparsers(dest="subparser_name", help="Sub command help")
 bench_parser = subs.add_parser("bench", help="Bench mark render times")
-bench_parser.set_defaults(func=qgis2img.render.run)
+bench_parser.set_defaults(func=run)
 
 bench_parser.add_argument('file', help="Project file to load into QGIS")
 bench_parser.add_argument('--size', type=int, nargs=2, default=[1580, 906], help="Image output size")
@@ -18,7 +18,7 @@ bench_parser.add_argument('--types', choices=['layer', 'project', 'layer|project
                                                                                  "all layers as the if the projcet is open in QGIS.")
 
 export_parser = subs.add_parser("export", help="Export a image of the project")
-export_parser.set_defaults(func=qgis2img.render.run)
+export_parser.set_defaults(func=run)
 export_parser.add_argument('file', help="Project file to export")
 export_parser.add_argument('--size', type=int, nargs=2, default=[1580, 906], help="Image output size")
 


### PR DESCRIPTION
Otherwise qgis2img fails to load:

martin@zenbook:~/qgis/qgis2img$ python qgis2img bench --types project /data/gis/x.qgs
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/martin/qgis/qgis2img/qgis2img/__main__.py", line 3, in <module>
    import qgis2img.render
ImportError: No module named qgis2img.render
